### PR TITLE
bumps tango minor version so cargo test works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build = "tango-build.rs"
 # to the build-dependencies.
 
 [build-dependencies]
-tango = "0.7.*"
+tango = "0.8.*"
 
 # Since the lib may be a tango file stored in `src/lib.md`, we need to
 # explicitly specify that this is a library project with a `[lib]`


### PR DESCRIPTION
Running `cargo test` on a fresh clone of repo fails to compile.  Bumping the minor version of `tango` runs the test as advertised and generates the `.rs` and `.md` files.